### PR TITLE
Short-pathed Scheduler for vLLM-Omni

### DIFF
--- a/docs/architecture/diffusion_executor_worker_runner.md
+++ b/docs/architecture/diffusion_executor_worker_runner.md
@@ -1,0 +1,307 @@
+# v1 Diffusion Components: Executor, Worker, Model Runner (Interfaces & Flow)
+
+## Introduction
+
+Background
+- vLLM v1 was originally optimized for autoregressive text generation. Diffusion models (e.g., UNet/DiT + VAE + scheduler) are non‑autoregressive and run a fixed number of denoising steps. They do not use the KV cache or token sampling/logprobs pipeline.
+
+Purpose
+- Add first‑class diffusion support while strictly reusing v1 interfaces and the canonical execution flow: EngineCore → Executor → Worker → GPUModelRunner. External entry points and the main run loop remain unchanged.
+
+Scope
+- Define a DiffusionModelRunner and a Worker configuration that minimally adapts the GPU worker path for diffusion.
+- Provide a second, no‑worker DiffusersPipelineExecutor for direct Diffusers pipeline execution (single process), alongside the standard MultiprocExecutor path.
+- Keep EngineCore and Scheduler interfaces stable; diffusion behavior is expressed through the same methods and data containers.
+
+Core design features
+- Inheritance strategy: DiffusionModelRunner extends GPUModelRunner; Worker remains GPUWorker (with optional minimal overrides only to initialize the diffusion runner); standard MultiprocExecutor is reused as‑is. A no‑worker DiffusersPipelineExecutor extends Executor for single‑process use.
+- Data flow parity: schedule() → executor.execute_model() → scheduler.update_from_output(); Worker delegates to ModelRunner; ModelRunner returns ModelRunnerOutput.
+- Outputs: Reuse ModelRunnerOutput; diffusion results are carried as tensors (e.g., via pooler_output), leaving text‑specific fields as orginal vllm.
+- KV cache: Treated as not required; when not registered in vllm_config, KV‑related initialization becomes a no‑op automatically.
+- Distributed: Existing TP/PP/DP initialization, process orchestration, profiling, and sleep/wake behaviors remain intact for the worker‑based path.
+- Acceleration: Torch compile/CUDA Graph warmup follows existing compile_or_warm_up_model hooks or the pipeline executor’s warmup helper.
+
+Assumptions and non‑goals
+- No prompt logprobs, grammar bitmask, or token sampler in diffusion.
+- No new public RPCs are added; we rely on existing EngineCore/Executor/Worker/Runner calls.
+- Scheduler retains the same interface (see the separate diffusion scheduler design doc for bucketing key definition and step/shape grouping).
+
+Deliverables
+- This design and the interface skeletons for: DiffusionModelRunner, (config‑selected) Worker with minimal overrides, MultiprocExecutor reuse, and DiffusersPipelineExecutor (no worker).
+- Clear data flow and compatibility notes to ensure coherence across EngineCore, executors, workers, and runners.
+
+Reading guide
+- Canonical v1 Call Path gives the end‑to‑end flow we preserve.
+- Executor covers both the reused MultiprocExecutor and the no‑worker DiffusersPipelineExecutor.
+- Worker explains the minimal inheritance strategy from GPUWorker.
+- Model Runner enumerates overridden vs. kept methods for diffusion.
+
+## Canonical v1 Call Path (for context)
+```python
+# class: EngineCore
+# EngineCore.step (simplified)
+class EngineCore:
+    def step(self):
+        scheduler_output = scheduler.schedule()
+        model_output = executor.execute_model(scheduler_output)
+        engine_outputs = scheduler.update_from_output(
+            scheduler_output, model_output
+        )
+        return engine_outputs
+```
+
+```python
+# class: MultiprocExecutor (v1)
+from concurrent.futures import Future
+from typing import Union
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.executor.abstract import Executor
+
+class MultiprocExecutor(Executor):
+    # Single RPC hop
+    def execute_model(
+        self, scheduler_output
+    ) -> Union[ModelRunnerOutput, Future[ModelRunnerOutput]]:
+        output = collective_rpc("execute_model", args=(scheduler_output, ))
+        return output
+```
+
+```python
+# class: GPUWorker (v1)
+# Required v1 method
+from vllm.worker.worker_base import WorkerBase
+from vllm.v1.outputs import ModelRunnerOutput
+
+class GPUWorker(WorkerBase):
+    def execute_model(self, scheduler_output) -> ModelRunnerOutput:
+        # (driver/TP metadata broadcast handled by LocalOrDistributedWorkerBase subclasses)
+        return self.model_runner.execute_model(
+            scheduler_output=scheduler_output,
+            intermediate_tensors=None,
+        )
+```
+
+
+## Executor
+
+### Function map (Executor)
+
+#### 1) Inherited and overridden
+```python
+# None required for diffusion. Reuse MultiprocExecutor as-is.
+# Worker class selection is driven by vllm_config; no _init_executor override.
+```
+<!-- 
+
+#### Multi-worker (TP/PP/DP) behavior and aggregation (Executor)
+- No KVConnector in diffusion by default → `kv_output_aggregator` is not used; the path short-circuits as in v1 when `kv_transfer_config` is None.
+- Executor collects output only from the output rank, consistent with v1:
+  - `output_rank = world_size - tensor_parallel_size` (i.e., TP0 of the last PP stage).
+  - Other ranks participate in compute but do not emit final `ModelRunnerOutput`.
+- Pipeline Parallel (PP):
+  - Intermediate PP stages return `IntermediateTensors` only; last PP stage returns `ModelRunnerOutput`.
+  - Executor receives only from `output_rank`.
+- Tensor Parallel (TP):
+  - TP ranks collaborate; TP0 produces/holds the final tensors for return.
+  - Executor still receives only from `output_rank`.
+- Data Parallel (DP):
+  - Each DP group executes independently; each group’s executor returns its own `output_rank` result.
+- Async batches (batch queue / `max_concurrent_batches>1`):
+  - Results are returned via `Future`, but still only from `output_rank`; no cross-worker aggregation is needed.
+ - Worker/Runner type is resolved from vllm_config (e.g., `worker_cls`, `model_cls`), not hardcoded in the executor. -->
+
+### Diffusers Pipeline Executor (no worker)
+
+A single-process executor that directly runs the Diffusers pipeline without spawning workers or using RPC. Interfaces remain identical to `Executor` so the EngineCore loop is unchanged.
+
+#### Function map（Pipeline Executor）
+
+##### 1) Inherited and overridden
+```python
+from concurrent.futures import Future
+from typing import Optional, Union, Callable, Any
+import torch
+import torch.nn as nn
+from vllm.v1.executor.abstract import Executor
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.tasks import SupportedTask
+from diffusers import DiffusionPipeline
+
+class DiffusersPipelineExecutor(Executor):
+    supports_pp: bool = False  # Single-process, no TP/PP/DP
+
+    def _init_executor(self) -> None:
+        # Called by ExecutorBase.__init__
+        self._failure_callback: Optional[Callable[[], None]] = None
+        self._device = self._resolve_device()
+        self._dtype = self._resolve_dtype()
+        self._pipeline = self._build_pipeline(device=self._device, dtype=self._dtype)
+        self._profiler = None
+        self._is_failed = False
+        self.is_sleeping = False
+        self.sleeping_tags: set[str] = set()
+    
+    # major functions to build/run diffusers pipeline
+    def _build_pipeline(self, device:torch.device, dtype:torch.dtype)->DiffusionPipeline:
+        model_name = "Qwen/Qwen-Image"
+
+        self.pipe = DiffusionPipeline.from_pretrained(model_name, torch_dtype=dtype)
+        self.pipe = pipe.to(device)
+
+    def _run_pipeline(self, scheduler_output) -> ModelRunnerOutput: ...
+        positive_magic = {
+            "en": ", Ultra HD, 4K, cinematic composition.", # for english prompt
+            "zh": ", 超清，4K，电影级构图." # for chinese prompt
+        }
+
+        # Generate image
+        prompt_embeds = self._get_and_process_prompt_embeds(scheduler_output, positive_magic)
+        negtive_prompt_embeds = self.pipe.embed_prompt(" ")
+
+
+        # Generate with different aspect ratios
+        aspect_ratios = {
+            "1:1": (1328, 1328),
+            "16:9": (1664, 928),
+            "9:16": (928, 1664),
+            "4:3": (1472, 1140),
+            "3:4": (1140, 1472),
+            "3:2": (1584, 1056),
+            "2:3": (1056, 1584),
+        }
+
+        width, height = aspect_ratios["16:9"]
+
+        image = pipe(
+            prompt_embeds=prompt_embeds,
+            negtive_prompt_embeds=negtive_prompt_embeds,
+            width=width,
+            height=height,
+            num_inference_steps=50,
+            true_cfg_scale=4.0,
+            generator=torch.Generator(device="cuda").manual_seed(42)
+        ).images[0]
+
+        output = self.wrap_image_as_ModelRunnerOutput(image)
+        return output
+
+    # ---- Internal helpers (implementation-specific, not public API) ----
+    def _resolve_device(self): ...
+    def _resolve_dtype(self): ...
+    def _get_model(self) -> nn.Module: ...
+    def _get_and_process_prompt_embeds(self, scheduler_output, positive_magic):
+        ...
+        #append the positive_magic to prompt and embed them to prompt embed tensors
+
+    # Functions related to workers should either raise NotImplementedError
+    # or return empty defaults in this no-worker executor.
+
+    def collective_rpc(self, method, timeout=None, args=(), kwargs=None) -> list[Any]:
+        # No workers in pipeline executor
+        raise NotImplementedError("No workers in DiffusersPipelineExecutor")
+
+    def initialize_from_config(self, kv_cache_configs: list[KVCacheConfig]) -> None:
+        return  # no-op (pipeline already built in _init_executor)
+
+    def register_failure_callback(self, callback):
+        self._failure_callback = callback
+
+    def determine_available_memory(self) -> list[int]:  # bytes
+        # Single device; return [available_bytes]. If CPU-only, return [0].
+        return [self._determine_available_bytes(self._device)]
+
+```
+
+
+
+## Worker
+
+### Inheritance strategy
+Prefer reusing the mature GPU Worker end-to-end. Worker class is selected by configuration (vllm_config). Do not add a new executor-specific worker binding. If customization is needed, override only `init_device` to construct the `DiffusionModelRunner`; all other behaviors (device init details, profiling, sleep/wake, PP/TP comms, execute path) remain from `vllm/v1/worker/gpu_worker.py::Worker`.
+
+
+
+### Function map (Worker)
+#### 1) Inherited and overridden
+```python
+# Optional: only if you need to plug a custom DiffusionModelRunner.
+from vllm.v1.worker.gpu_worker import Worker as GPUWorker
+from vllm.v1.worker.diffusion_model_runner import DiffusionModelRunner
+
+class Worker(GPUWorker):
+    def init_device(self) -> None:
+        #those related to device check and init
+        ...
+        
+        self.model_runner = DiffusionModelRunner(self.vllm_config, ...)
+```
+
+## Model Runner
+
+### Function map (Model Runner)
+#### 1) Inherited and overridden
+Those parts relied to the KV Cache will be omitted if we do not register the model to the vllm config. The engine core will view it as do not require KV Cache, and handle it properly
+
+Reuse `vllm/v1/outputs.py::ModelRunnerOutput`：
+- DiffusionModelRunner: Use the `pooler_output=[Tensor,...]` to return multi modal tensors
+- ARModelRunner: Use the `pooler_output=[Tensor,...]` to return hidden states.
+```python
+from typing import Optional, Union
+import torch
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+from vllm.v1.outputs import ModelRunnerOutput
+
+
+class DiffusionModelRunner(GPUModelRunner):
+    @torch.inference_mode()
+    def execute_model(
+        self,
+        scheduler_output: "SchedulerOutput",
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+    ) -> Union[ModelRunnerOutput, IntermediateTensors]:
+        ...
+        return ModelRunnerOutput(
+            req_ids=[...],
+            req_id_to_index={...},
+            sampled_token_ids=[],
+            spec_token_ids=None,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[Tensor,...],         # Return Hidden states
+            kv_connector_output=None,
+            num_nans_in_logits=None,
+        )# return multi modal tensors via pooler_output=[Tensor,...]
+
+
+class ARModelRunner(GPUModelRunner):
+    @torch.inference_mode()
+    def execute_model(
+        self,
+        scheduler_output: "SchedulerOutput",
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+    ) -> Union[ModelRunnerOutput, IntermediateTensors]:
+        ...
+        return ModelRunnerOutput(
+            req_ids=[...],
+            req_id_to_index={...},
+            sampled_token_ids=[],
+            spec_token_ids=None,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[Tensor,...],         # Return Hidden states
+            kv_connector_output=None,
+            num_nans_in_logits=None,
+        )# return hidden states via pooler_output=[Tensor,...]
+```
+
+
+## Minimal data flow (end-to-end)
+1) EngineCore (DiffusionEngineCore): `_initialize_kv_caches` produces empty KV Cache; calls executor to warm up.
+2) EngineCore.step(): `schedule()` (shape/step bucketing) → `executor.execute_model(scheduler_output)` → `scheduler.update_from_output(...)`.
+3) Executor: single RPC to Workers `execute_model`.
+4) Worker: prepares/broadcasts metadata if needed → `runner.execute_model(...)`.
+5) Runner: runs diffusion (fixed T steps or pipeline)/ runs AR Model with hidden state output → returns `ModelRunnerOutput(pooler_output=...)`.
+6) Scheduler: marks those requests finished and yields `EngineCoreOutputs` back to EngineCore.
+
+

--- a/vllm_omni/core/sched/__init__.py
+++ b/vllm_omni/core/sched/__init__.py
@@ -1,0 +1,3 @@
+from .diffusion_scheduler import Scheduler as DiffusionScheduler
+
+__all__ = ["DiffusionScheduler"]

--- a/vllm_omni/core/sched/ar_scheduler.py
+++ b/vllm_omni/core/sched/ar_scheduler.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from vllm.v1.core.sched.scheduler import Scheduler as VLLMScheduler
+from vllm.v1.core.sched.scheduler import SchedulerOutput, ModelRunnerOutput, EngineCoreOutputs, Request, RequestStatus, SpecDecodingStats, defaultdict, Optional
+from vllm.v1.core.sched.output import NewRequestData
+from vllm.v1.core.sched.request_queue import create_request_queue
+from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput
+
+
+class Scheduler(VLLMScheduler):
+    """Omni AR Scheduler: 在构造 EngineCoreOutput 时写入 output_type。
+
+    本类继承 vLLM V1 的 Scheduler，仅覆写在组装 EngineCoreOutput 处的行为。
+    其他调度逻辑沿用上游实现。
+    """
+
+    # We override only the section where EngineCoreOutput is appended.
+    # To avoid forking the whole file, we alias update_from_outputs and wrap
+    # the precise instantiation site if needed. For simplicity and
+    # maintainability, we duplicate the minimal block using super() flow.
+
+    def update_from_outputs(self, model_runner_output: ModelRunnerOutput) -> EngineCoreOutputs:  # type: ignore[override]
+        outputs = super().update_from_outputs(model_runner_output)
+        # All EngineCoreOutput objects in outputs.outputs lack explicit omni
+        # output_type. We now populate them if not set.
+        output_type = getattr(self.vllm_config.model_config, "engine_output_type", None)
+        if output_type:
+            for eco in outputs.outputs:
+                if getattr(eco, "output_type", None) is None:
+                    eco.output_type = output_type
+        return outputs
+
+

--- a/vllm_omni/core/sched/diffusion_scheduler.py
+++ b/vllm_omni/core/sched/diffusion_scheduler.py
@@ -9,13 +9,8 @@ import time
 class Scheduler(VLLMScheduler):
     def schedule(self) -> SchedulerOutput:
         """Diffusion fast path:
-<<<<<<< HEAD
-        - Assign 1 placeholder token for requests (zero-prompt friendly) to trigger a single execution.
-        - If no diffusion-eligible requests are scheduled, fall back to the upstream vLLM default scheduler.
-=======
         - For requests with prompt length 0, allocate 1 placeholder token and trigger a single execution.
         - If no requests match the diffusion fast path, fall back to the upstream vLLM default scheduling.
->>>>>>> 4b26d07b46e80191b18daf82e77d4ce907974816
         """
 
         # Select diffusion-eligible requests (zero-prompt friendly; results returned via pooler_output)

--- a/vllm_omni/core/sched/diffusion_scheduler.py
+++ b/vllm_omni/core/sched/diffusion_scheduler.py
@@ -1,10 +1,11 @@
 from vllm.v1.core.sched.scheduler import Scheduler as VLLMScheduler
-from vllm.v1.core.sched.scheduler import SchedulerOutput, ModelRunnerOutput, EngineCoreOutputs, EngineCoreOutput, Request, RequestStatus, SpecDecodingStats, defaultdict, Optional
+from vllm.v1.core.sched.scheduler import SchedulerOutput, ModelRunnerOutput, EngineCoreOutputs, Request, RequestStatus, SpecDecodingStats, defaultdict, Optional
 from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.core.sched.request_queue import create_request_queue
 from vllm.v1.engine import EngineCoreEventType
 from vllm.distributed.kv_events import KVEventBatch
 import time
+from vllm_omni.engine import EngineCoreOutput
 
 class Scheduler(VLLMScheduler):
     def schedule(self) -> SchedulerOutput:
@@ -256,6 +257,7 @@ class Scheduler(VLLMScheduler):
                         kv_transfer_params=kv_transfer_params,
                         num_cached_tokens=request.num_cached_tokens,
                         multimodal_outputs=multimodal_outputs,
+                        output_type=getattr(self.vllm_config.model_config, "engine_output_type", None),
                     ))
 
             else:

--- a/vllm_omni/core/sched/diffusion_scheduler.py
+++ b/vllm_omni/core/sched/diffusion_scheduler.py
@@ -133,13 +133,7 @@ class Scheduler(VLLMScheduler):
         # Update internal state (advance num_computed_tokens, free encoder inputs, etc.)
         self._update_after_schedule(scheduler_output)
         return scheduler_output
-    """
-    Scheduler for the diffusion model.
-    This scheduler is modified to stop the request immediately for the diffusion model.
-    This is because the diffusion model can generate the final image/audio in one step.
-    Note: This is just a minimal modification to the original scheduler, and there should be some further efforts to optimize the scheduler. 
-    The original scheduler is still used for the AR model.
-    """
+
     def update_from_output(
         self,
         scheduler_output: SchedulerOutput,

--- a/vllm_omni/core/sched/diffusion_scheduler.py
+++ b/vllm_omni/core/sched/diffusion_scheduler.py
@@ -8,12 +8,12 @@ import time
 
 class Scheduler(VLLMScheduler):
     def schedule(self) -> SchedulerOutput:
-        """扩散快速通道：
-        - prompt 长度为 0 的请求，分配 1 个占位 token，触发一次执行。
-        - 如果未匹配到扩散快速通道请求，退回上游 vLLM 的默认调度。
+        """Diffusion fast path:
+        - Assign 1 placeholder token for requests (zero-prompt friendly) to trigger a single execution.
+        - If no diffusion-eligible requests are scheduled, fall back to the upstream vLLM default scheduler.
         """
 
-        # 选出零 prompt 且使用 pooling（扩散结果经 pooler_output 回传）的请求
+        # Select diffusion-eligible requests (zero-prompt friendly; results returned via pooler_output)
         token_budget = self.max_num_scheduled_tokens
         capacity = self.max_num_running_reqs - len(self.running)
         scheduled_timestamp = time.monotonic()
@@ -28,21 +28,21 @@ class Scheduler(VLLMScheduler):
         scheduled_encoder_inputs: dict[str, list[int]] = {}
         structured_output_request_ids: dict[str, int] = {}
 
-        # 临时队列：保持等待队列顺序，不破坏非扩散请求
+        # Temporary queue: preserve waiting order; do not disturb non-diffusion requests
         skipped_waiting_requests = create_request_queue(self.policy)
 
-        # 快速通道挑选并调度（所有请求都视为扩散请求，不依赖 pooling_params）
+        # Fast-path selection and scheduling (treat all requests as diffusion; no reliance on pooling_params)
         while self.waiting and token_budget > 0 and capacity > 0:
             request = self.waiting.peek_request()
-            # 统一按扩散处理。若未来需要条件开关，可接入配置或请求标记。
+            # Handle uniformly as diffusion. Optional: gate by config or per-request flag in the future.
             is_diffusion = True
             if not is_diffusion:
-                # 暂存到跳过队列，稍后归还到等待队列头部
+                # Temporarily store in the skipped queue; will be prepended back to waiting
                 self.waiting.pop_request()
                 skipped_waiting_requests.prepend_request(request)
                 continue
 
-            # 为扩散请求分配一个占位 token（最小化资源）
+            # Allocate 1 placeholder token for diffusion requests (minimal resource)
             num_new_tokens = min(1, token_budget)
             new_blocks = self.kv_cache_manager.allocate_slots(
                 request,
@@ -50,12 +50,12 @@ class Scheduler(VLLMScheduler):
                 num_lookahead_tokens=self.num_lookahead_tokens,
             )
             if new_blocks is None:
-                # 无法分配（显存紧张等），停止快速通道尝试，回退到默认调度
-                # 将当前 request 放回等待队列头
-                # 注意：此处不改变原队列顺序
+                # If allocation fails (e.g., memory pressure), stop fast-path attempt and fall back to default scheduler
+                # Put the current request back to the head of the waiting queue
+                # Note: this does not change the original queue order
                 break
 
-            # 正式调度该请求
+            # Officially schedule this request
             request = self.waiting.pop_request()
             self.running.append(request)
             request.status = RequestStatus.RUNNING
@@ -69,15 +69,15 @@ class Scheduler(VLLMScheduler):
             capacity -= 1
             scheduled_new_reqs.append(request)
 
-        # 归还被跳过的等待请求
+        # Return skipped waiting requests to the head
         if skipped_waiting_requests:
             self.waiting.prepend_requests(skipped_waiting_requests)
 
-        # 若快速通道未调度任何请求，则回退到原始调度逻辑
+        # If no fast-path scheduling happened, fall back to original scheduling
         if not num_scheduled_tokens:
             return super().schedule()
 
-        # 计算公共前缀块（与 v1 对齐）
+        # Compute common prefix blocks (aligned with v1)
         num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
         if self.running:
             any_request = self.running[0]
@@ -91,7 +91,7 @@ class Scheduler(VLLMScheduler):
             scheduled_spec_decode_tokens,
         )
 
-        # 组装 SchedulerOutput
+        # Build SchedulerOutput
         new_reqs_data = [
             NewRequestData.from_request(req, req_to_new_block_ids[req.request_id])
             for req in scheduled_new_reqs
@@ -119,18 +119,18 @@ class Scheduler(VLLMScheduler):
             grammar_bitmask=grammar_bitmask,
         )
 
-        # KVTransfer：封装元信息
+        # KVTransfer: wrap metadata
         if self.connector is not None:
             meta = self.connector.build_connector_meta(scheduler_output)
             scheduler_output.kv_connector_metadata = meta
 
-        # 发布 KV 事件（与 v1 对齐）
+        # Publish KV events (aligned with v1)
         events = self.kv_cache_manager.take_events()
         if events:
             batch = KVEventBatch(ts=time.time(), events=events)
             self.kv_event_publisher.publish(batch)
 
-        # 更新内部状态（推进 num_computed_tokens，释放 encoder 输入等）
+        # Update internal state (advance num_computed_tokens, free encoder inputs, etc.)
         self._update_after_schedule(scheduler_output)
         return scheduler_output
     """
@@ -204,9 +204,9 @@ class Scheduler(VLLMScheduler):
             if pooler_outputs:
                 pooler_output = pooler_outputs[req_index]
 
-            # 扩散请求：单步完成，直接标记完成并释放资源
+            # Diffusion request: single-step completion; mark finished and free resources immediately
             request.status = RequestStatus.FINISHED_STOPPED
-            # 可选：标注停止原因，便于前端区分（不影响协议）
+            # Optional: annotate stop_reason for frontend clarity (protocol-neutral)
             request.stop_reason = request.stop_reason or "diffusion_done"
             kv_transfer_params = self._free_request(request)
             if status_before_stop == RequestStatus.RUNNING:

--- a/vllm_omni/core/sched/diffusion_scheduler.py
+++ b/vllm_omni/core/sched/diffusion_scheduler.py
@@ -1,0 +1,310 @@
+from vllm.v1.core.sched.scheduler import Scheduler as VLLMScheduler
+from vllm.v1.core.sched.scheduler import SchedulerOutput, ModelRunnerOutput, EngineCoreOutputs, EngineCoreOutput, Request, RequestStatus, SpecDecodingStats, defaultdict, Optional
+from vllm.v1.core.sched.output import NewRequestData
+from vllm.v1.core.sched.request_queue import create_request_queue
+from vllm.v1.engine import EngineCoreEventType
+from vllm.distributed.kv_events import KVEventBatch
+import time
+
+class Scheduler(VLLMScheduler):
+    def schedule(self) -> SchedulerOutput:
+        """扩散快速通道：
+        - prompt 长度为 0 的请求，分配 1 个占位 token，触发一次执行。
+        - 如果未匹配到扩散快速通道请求，退回上游 vLLM 的默认调度。
+        """
+
+        # 选出零 prompt 且使用 pooling（扩散结果经 pooler_output 回传）的请求
+        token_budget = self.max_num_scheduled_tokens
+        capacity = self.max_num_running_reqs - len(self.running)
+        scheduled_timestamp = time.monotonic()
+
+        scheduled_new_reqs: list[Request] = []
+        scheduled_resumed_reqs: list[Request] = []
+        scheduled_running_reqs: list[Request] = []
+
+        req_to_new_block_ids: dict[str, tuple[list[int], ...]] = {}
+        num_scheduled_tokens: dict[str, int] = {}
+        scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+        scheduled_encoder_inputs: dict[str, list[int]] = {}
+        structured_output_request_ids: dict[str, int] = {}
+
+        # 临时队列：保持等待队列顺序，不破坏非扩散请求
+        skipped_waiting_requests = create_request_queue(self.policy)
+
+        # 快速通道挑选并调度（所有请求都视为扩散请求，不依赖 pooling_params）
+        while self.waiting and token_budget > 0 and capacity > 0:
+            request = self.waiting.peek_request()
+            # 统一按扩散处理。若未来需要条件开关，可接入配置或请求标记。
+            is_diffusion = True
+            if not is_diffusion:
+                # 暂存到跳过队列，稍后归还到等待队列头部
+                self.waiting.pop_request()
+                skipped_waiting_requests.prepend_request(request)
+                continue
+
+            # 为扩散请求分配一个占位 token（最小化资源）
+            num_new_tokens = min(1, token_budget)
+            new_blocks = self.kv_cache_manager.allocate_slots(
+                request,
+                num_new_tokens,
+                num_lookahead_tokens=self.num_lookahead_tokens,
+            )
+            if new_blocks is None:
+                # 无法分配（显存紧张等），停止快速通道尝试，回退到默认调度
+                # 将当前 request 放回等待队列头
+                # 注意：此处不改变原队列顺序
+                break
+
+            # 正式调度该请求
+            request = self.waiting.pop_request()
+            self.running.append(request)
+            request.status = RequestStatus.RUNNING
+            if self.log_stats:
+                request.record_event(EngineCoreEventType.SCHEDULED,
+                                     scheduled_timestamp)
+
+            req_to_new_block_ids[request.request_id] = new_blocks.get_block_ids()
+            num_scheduled_tokens[request.request_id] = num_new_tokens
+            token_budget -= num_new_tokens
+            capacity -= 1
+            scheduled_new_reqs.append(request)
+
+        # 归还被跳过的等待请求
+        if skipped_waiting_requests:
+            self.waiting.prepend_requests(skipped_waiting_requests)
+
+        # 若快速通道未调度任何请求，则回退到原始调度逻辑
+        if not num_scheduled_tokens:
+            return super().schedule()
+
+        # 计算公共前缀块（与 v1 对齐）
+        num_common_prefix_blocks = [0] * len(self.kv_cache_config.kv_cache_groups)
+        if self.running:
+            any_request = self.running[0]
+            num_common_prefix_blocks = (
+                self.kv_cache_manager.get_num_common_prefix_blocks(
+                    any_request, len(self.running)))
+
+        grammar_bitmask = self.structured_output_manager.grammar_bitmask(
+            self.requests,
+            structured_output_request_ids,
+            scheduled_spec_decode_tokens,
+        )
+
+        # 组装 SchedulerOutput
+        new_reqs_data = [
+            NewRequestData.from_request(req, req_to_new_block_ids[req.request_id])
+            for req in scheduled_new_reqs
+        ]
+        cached_reqs_data = self._make_cached_request_data(
+            scheduled_running_reqs,
+            scheduled_resumed_reqs,
+            num_scheduled_tokens,
+            scheduled_spec_decode_tokens,
+            req_to_new_block_ids,
+        )
+
+        total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
+        scheduler_output = SchedulerOutput(
+            scheduled_new_reqs=new_reqs_data,
+            scheduled_cached_reqs=cached_reqs_data,
+            num_scheduled_tokens=num_scheduled_tokens,
+            total_num_scheduled_tokens=total_num_scheduled_tokens,
+            scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+            scheduled_encoder_inputs=scheduled_encoder_inputs,
+            num_common_prefix_blocks=num_common_prefix_blocks,
+            finished_req_ids=self.finished_req_ids,
+            free_encoder_input_ids=self.encoder_cache_manager.get_freed_ids(),
+            structured_output_request_ids=structured_output_request_ids,
+            grammar_bitmask=grammar_bitmask,
+        )
+
+        # KVTransfer：封装元信息
+        if self.connector is not None:
+            meta = self.connector.build_connector_meta(scheduler_output)
+            scheduler_output.kv_connector_metadata = meta
+
+        # 发布 KV 事件（与 v1 对齐）
+        events = self.kv_cache_manager.take_events()
+        if events:
+            batch = KVEventBatch(ts=time.time(), events=events)
+            self.kv_event_publisher.publish(batch)
+
+        # 更新内部状态（推进 num_computed_tokens，释放 encoder 输入等）
+        self._update_after_schedule(scheduler_output)
+        return scheduler_output
+    """
+    Scheduler for the diffusion model.
+    This scheduler is modified to stop the request immediately for the diffusion model.
+    This is because the diffusion model can generate the final image/audio in one step.
+    Note: This is just a minimal modification to the original scheduler, and there should be some further efforts to optimize the scheduler. 
+    The original scheduler is still used for the AR model.
+    """
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, EngineCoreOutputs]:
+        """Update the scheduler state based on the model runner output.
+
+        This method is modified to stop the request immediately for the diffusion model.
+        """
+        sampled_token_ids = model_runner_output.sampled_token_ids
+        spec_token_ids = model_runner_output.spec_token_ids
+        logprobs = model_runner_output.logprobs
+        prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        pooler_outputs = model_runner_output.pooler_output
+        num_nans_in_logits = model_runner_output.num_nans_in_logits
+        multimodal_outputs = model_runner_output.multimodal_outputs
+
+        outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        spec_decoding_stats: Optional[SpecDecodingStats] = None
+
+        # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
+        # the below loop can be a performance bottleneck. We should do our best
+        # to avoid expensive operations inside the loop.
+        stopped_running_reqs: set[Request] = set()
+        stopped_preempted_reqs: set[Request] = set()
+        for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
+            assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            if request is None:
+                # The request is already finished. This can happen if the
+                # request is aborted while the model is executing it (e.g.,
+                # in pipeline parallelism).
+                continue
+
+            req_index = model_runner_output.req_id_to_index[req_id]
+            generated_token_ids = sampled_token_ids[
+                req_index] if sampled_token_ids else []
+
+            scheduled_spec_token_ids = (
+                scheduler_output.scheduled_spec_decode_tokens.get(req_id))
+            if scheduled_spec_token_ids:
+                # num_computed_tokens represents the number of tokens
+                # processed in the current step, considering scheduled
+                # tokens and rejections. If some tokens are rejected,
+                # num_computed_tokens is decreased by the number of rejected
+                # tokens, where is given by:
+                # len(scheduled_spec_token_ids) + 1 - len(generated_token_ids).
+                num_tokens_rejected = (len(scheduled_spec_token_ids) + 1 -
+                                       len(generated_token_ids))
+                request.num_computed_tokens -= num_tokens_rejected
+                spec_decoding_stats = self.make_spec_decoding_stats(
+                    spec_decoding_stats,
+                    num_draft_tokens=len(scheduled_spec_token_ids),
+                    num_accepted_tokens=len(generated_token_ids) - 1)
+
+            new_logprobs = None
+            new_token_ids = generated_token_ids
+            kv_transfer_params = None
+            status_before_stop = request.status
+            pooler_output = None
+            if pooler_outputs:
+                pooler_output = pooler_outputs[req_index]
+
+            # 扩散请求：单步完成，直接标记完成并释放资源
+            request.status = RequestStatus.FINISHED_STOPPED
+            # 可选：标注停止原因，便于前端区分（不影响协议）
+            request.stop_reason = request.stop_reason or "diffusion_done"
+            kv_transfer_params = self._free_request(request)
+            if status_before_stop == RequestStatus.RUNNING:
+                stopped_running_reqs.add(request)
+            else:
+                stopped_preempted_reqs.add(request)
+
+            # Extract sample logprobs if needed.
+            if request.sampling_params is not None \
+                and request.sampling_params.logprobs is not None and logprobs:
+                # NOTE: once we support N tokens per step (spec decode),
+                # the outer lists can be of length > 1.
+                new_logprobs = logprobs.slice(req_index, req_index + 1)
+
+            if new_token_ids and self.structured_output_manager.should_advance(
+                    request):
+                # NOTE: structured_output_request
+                # should not be None if use_structured_output, we have
+                # check above, so safe to ignore type warning
+                request.structured_output_request.grammar.accept_tokens(  # type: ignore[union-attr]
+                    req_id, new_token_ids)
+
+            # spec_token_ids comes from the model runner output
+            if num_nans_in_logits is not None and req_id in num_nans_in_logits:
+                request.num_nans_in_logits = num_nans_in_logits[req_id]
+
+            # Add newly generated spec token ids to the request.
+            if spec_token_ids is not None:
+                if self.structured_output_manager.should_advance(request):
+                    metadata = request.structured_output_request
+                    # Needs to happen after new_token_ids are accepted.
+                    request.spec_token_ids = metadata.grammar.validate_tokens(  # type: ignore[union-attr]
+                        spec_token_ids[req_index])
+                else:
+                    request.spec_token_ids = spec_token_ids[req_index]
+
+            # Get prompt logprobs for this request.
+            prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
+            if new_token_ids or pooler_output is not None \
+                or kv_transfer_params:
+
+                # Add EngineCoreOutput for this Request.
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=req_id,
+                        new_token_ids=new_token_ids,
+                        finish_reason=request.get_finished_reason(),
+                        new_logprobs=new_logprobs,
+                        new_prompt_logprobs_tensors=prompt_logprobs_tensors,
+                        pooling_output=pooler_output,
+                        stop_reason=request.stop_reason,
+                        events=request.take_events(),
+                        kv_transfer_params=kv_transfer_params,
+                        num_cached_tokens=request.num_cached_tokens,
+                        multimodal_outputs=multimodal_outputs,
+                    ))
+
+            else:
+                # Invariant: EngineCore returns no partial prefill outputs.
+                assert not prompt_logprobs_tensors
+
+        # Remove the stopped requests from the running and waiting queues.
+        if stopped_running_reqs:
+            self.running = [
+                req for req in self.running if req not in stopped_running_reqs
+            ]
+        if stopped_preempted_reqs:
+            # This is a rare case and unlikely to impact performance.
+            self.waiting.remove_requests(stopped_preempted_reqs)
+
+        # KV Connector: update state for finished KV Transfers.
+        if model_runner_output.kv_connector_output:
+            self._update_from_kv_xfer_finished(
+                model_runner_output.kv_connector_output)
+
+        # Create EngineCoreOutputs for all clients that have requests with
+        # outputs in this step.
+        engine_core_outputs = {
+            client_index: EngineCoreOutputs(outputs=outs)
+            for client_index, outs in outputs.items()
+        }
+
+        finished_req_ids = self.finished_req_ids_dict
+        if finished_req_ids:
+            # Include ids of requests that finished since last outputs
+            # were sent.
+            for client_index, finished_set in finished_req_ids.items():
+                # Set finished request set in EngineCoreOutputs for this client.
+                if (eco := engine_core_outputs.get(client_index)) is not None:
+                    eco.finished_requests = finished_set
+                else:
+                    engine_core_outputs[client_index] = EngineCoreOutputs(
+                        finished_requests=finished_set)
+            finished_req_ids.clear()
+
+        if engine_core_outputs:
+            # Return stats to only one of the front-ends.
+            next(iter(engine_core_outputs.values())).scheduler_stats = (
+                self.make_stats(spec_decoding_stats))
+
+        return engine_core_outputs

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -10,9 +10,26 @@ from .cache_manager import DiffusionCacheManager
 from .models import DiffusionModel
 from .base import BaseDiffusionEngine
 
+
+
+from vllm.v1.engine import EngineCoreOutput as _BaseEngineCoreOutput  # type: ignore
+from typing import Optional
+
+
+class EngineCoreOutput(_BaseEngineCoreOutput):
+    """Omni EngineCoreOutput.
+
+    Currently identical to vLLM's EngineCoreOutput, which already includes
+    fields such as `output_type`. This subclass exists to enable Omni-side
+    overrides/extensions without affecting upstream vLLM.
+    """
+
+    output_type: Optional[str] = None
+
 __all__ = [
     "DiffusionStepManager",
     "DiffusionCacheManager",
     "DiffusionModel",
     "BaseDiffusionEngine",
+    "EngineCoreOutput",
 ]

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from vllm.utils import FlexibleArgumentParser  # type: ignore
+from vllm.engine.arg_utils import EngineArgs as _BaseEngineArgs  # type: ignore
+from vllm.engine.arg_utils import AsyncEngineArgs as _BaseAsyncEngineArgs  # type: ignore
+
+@dataclass
+class EngineArgs(_BaseEngineArgs):
+    """Omni 扩展的 EngineArgs。
+
+    - 新增 `engine_output_type` 字段，用于通过 CLI/代码从 LLM 层设置输出类型，
+      在 create_engine_config 阶段写入到 `config.model_config.engine_output_type`。
+    """
+
+    engine_output_type: Optional[str] = None
+
+    @staticmethod
+    def add_cli_args(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
+        # 先添加 vLLM 标准参数
+        parser = _BaseEngineArgs.add_cli_args(parser)
+        # 再添加 omni 扩展参数
+        parser.add_argument(
+            "--engine-output-type",
+            type=str,
+            default=EngineArgs.engine_output_type,
+            help=(
+                "Declare EngineCoreOutput.output_type (e.g., 'text', 'image', "
+                "'text+image', 'latent'). This will be written into "
+                "model_config.engine_output_type for schedulers to use."
+            ),
+        )
+        return parser
+
+    def create_engine_config(self, *args: Any, **kwargs: Any):  # type: ignore[override]
+        config = super().create_engine_config(*args, **kwargs)
+        # 将 CLI/代码传入的输出类型写入 model_config，供调度器读取
+        # We simply add the engine_output_type attribute to the config, to avoid the complexity of changing the VllmConfig class
+        # and all the files that use it like the vllm.engine.arg_utils.EngineArgs.create_engine_config().
+        setattr(config.model_config, "engine_output_type", self.engine_output_type)
+        return config
+
+
+#Also add the engine_output_type to the AsyncEngineArgs
+@dataclass
+class AsyncEngineArgs(_BaseAsyncEngineArgs):
+    """Omni 扩展的 AsyncEngineArgs。
+
+    - 新增 `engine_output_type` 字段，用于通过 CLI/代码从 LLM 层设置输出类型，
+      在 create_engine_config 阶段写入到 `config.model_config.engine_output_type`。
+    """
+
+    engine_output_type: Optional[str] = None
+    
+    @staticmethod
+    def add_cli_args(parser: FlexibleArgumentParser, async_args_only: bool = False) -> FlexibleArgumentParser:
+        parser = _BaseAsyncEngineArgs.add_cli_args(parser, async_args_only)
+        parser.add_argument("--engine-output-type", type=str, default=AsyncEngineArgs.engine_output_type, help="Declare EngineCoreOutput.output_type (e.g., 'text', 'image', 'text+image', 'latent'). This will be written into model_config.engine_output_type for schedulers to use.")
+        return parser
+    
+    def create_engine_config(self, *args: Any, **kwargs: Any):  # type: ignore[override]
+        config = super().create_engine_config(*args, **kwargs)
+        # We simply add the engine_output_type attribute to the config, to avoid the complexity of changing the VllmConfig class
+        # and all the files that use it like the vllm.engine.arg_utils.AsyncEngineArgs.create_engine_config().
+        setattr(config.model_config, "engine_output_type", self.engine_output_type)
+        return config


### PR DESCRIPTION
# PR: Short-pathed Scheduler for vLLM-Omni (Updated)

## Summary
This PR introduces a short-pathed scheduler for non-autoregressive (diffusion) workloads in vLLM-Omni and merges the latest changes:
- Propagates `EngineCoreOutput.output_type` (e.g., "text", "image", "text+image", "latent"), driven by `VllmConfig.model_config.engine_output_type`.
- Extends `EngineArgs` and `AsyncEngineArgs` with `--engine-output-type`, wiring the value into `model_config.engine_output_type` during `create_engine_config()`.
- Adds an Omni AR Scheduler (inherits v1 Scheduler) to ensure AR outputs also carry `output_type`.

The canonical v1 loop (EngineCore → Executor → Worker → ModelRunner) is preserved. Diffusion workloads take a “single placeholder token” fast path to avoid AR-specific overhead.

## Motivation
- Diffusion is non-AR and step-bound, returning tensors (images/audio) instead of text. AR token-by-token scheduling adds unnecessary KV/scheduling overhead.
- An explicit output type is beneficial for downstream routing (UI, post-processing, multimodal aggregation).
- Keep vLLM v1 interface compatibility for low-risk integration.

## Design Overview
1. Scheduling
   - Diffusion fast path: `schedule()` allocates exactly 1 placeholder token to trigger a single execution. `update_from_output()` immediately finalizes the request and returns results via `pooler_output` (with legacy `multimodal_outputs` passthrough).
   - Omni AR Scheduler: post-processes outputs from the base scheduler to ensure `EngineCoreOutput.output_type` is populated for AR paths as well.
2. Output Type Propagation
   - vLLM `EngineCoreOutput` gains `output_type: Optional[str]`.
   - v1 Scheduler, v1 Diffusion Scheduler, Omni Diffusion Scheduler, and Omni AR Scheduler all inject `output_type` from `VllmConfig.model_config.engine_output_type`.
3. Config & Entrypoint
   - `EngineArgs` and `AsyncEngineArgs` support `--engine-output-type`, which is written into `model_config.engine_output_type` during `create_engine_config()`.
   - Legacy `multimodal_outputs` is still passed through for compatibility (deprecated).

## What’s in This PR
- Diffusion Scheduler (short path):
  - One placeholder token per request (no reliance on `pooling_params`).
  - Single-shot completion in `update_from_output()` with results in `pooler_output`; legacy `multimodal_outputs` preserved.
- Output Type Propagation:
  - `EngineCoreOutput.output_type` added at the vLLM core.
  - v1 Scheduler, v1 Diffusion Scheduler, Omni Diffusion Scheduler, and Omni AR Scheduler populate it from config.
- Configurability:
  - `--engine-output-type` (EngineArgs/AsyncEngineArgs) propagates to `model_config.engine_output_type` → Scheduler → `EngineCoreOutput.output_type`.

## Behavior and Compatibility
- No breaking public API changes; `EngineCoreOutput` adds an optional field.
- `pooler_output` carries latents and multimodal tensors; `multimodal_outputs` remains for compatibility (deprecated).
- Fully compatible with v1 backends and DP/TP/PP.
- 
## Implementation Notes
### schedule()
- Picks eligible waiting requests (capacity and budget constraints).
- Allocates one placeholder token per request.
- Emits KV-related events and builds standard `SchedulerOutput`.

### update_from_output()
- Extracts `pooler_output` (and legacy `multimodal_outputs`).
- Marks the request finished (STOP), frees resources.
- Builds `EngineCoreOutput` with:
  - `output_type` from `VllmConfig.model_config.engine_output_type`
  - `pooler_output` (contains latents and multimodal tensors)
  - `multimodal_outputs` for compatibility
  - Empty token/logprob arrays (not relevant for diffusion)

## Configuration
- Python:
  - `args = EngineArgs(model="...", engine_output_type="image"); config = args.create_engine_config()`
  - `config.model_config.engine_output_type` will be propagated into `EngineCoreOutput.output_type`.


## Files Touched (Core)
- vLLM-Omni:
  - `vllm_omni/core/sched/diffusion_scheduler.py` (short path Diffusion scheduler; inject output_type)
  - `vllm_omni/core/sched/ar_scheduler.py` (Omni AR scheduler; ensure output_type)
  - `vllm_omni/engine/output_processor.py` (vLLM-inheriting processors and factory)
  - `vllm_omni/engine/arg_utils.py` (EngineArgs/AsyncEngineArgs support --engine-output-type)
  - `vllm_omni/engine/__init__.py` (exports)
